### PR TITLE
ci: closure-aware cachix filter + new signing key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,25 @@ jobs:
       # already serves — the full closure would blow the 5 GB free tier.
       # pragmata-pro is a commercial font and must never reach a public
       # cache; chrome/obsidian are repackaged downloads not worth caching.
+      # CRITICAL: cachix push uploads the CLOSURE of each given path, so
+      # name-filtering alone is not enough — any aggregate (system-path,
+      # profiles) referencing an excluded package would drag it back in.
+      # Subtracting the referrers-closure of excluded paths guarantees no
+      # pushed path transitively contains them.
       - name: Push locally-built paths to Cachix
         if: env.CACHIX_AUTH_TOKEN != ''
         run: |
           nix path-info --all --json | jq -r 'to_entries[]
             | select(.key | endswith(".drv") | not)
             | select(.key | test("-source$") | not)
-            | select(.key | test("pragmata|google-chrome|obsidian") | not)
             | select((.value.ca // "") == "")
             | select(((.value.signatures // []) | map(startswith("cache.nixos.org")) | any) | not)
-            | .key' | cachix push "$CACHIX_CACHE"
+            | .key' | sort -u > candidates.txt
+          grep -E 'pragmata|google-chrome|obsidian' candidates.txt > bad.txt || true
+          if [ -s bad.txt ]; then
+            xargs nix-store -q --referrers-closure < bad.txt | sort -u > excluded.txt
+          else
+            : > excluded.txt
+          fi
+          comm -23 candidates.txt excluded.txt | tee pushed.txt | cachix push "$CACHIX_CACHE"
+          echo "Pushed $(wc -l < pushed.txt) paths ($(wc -l < excluded.txt) excluded as non-redistributable or depending on such)"

--- a/modules/nixos/core/nix.nix
+++ b/modules/nixos/core/nix.nix
@@ -25,7 +25,7 @@
           auto-optimise-store = true;
           extra-substituters = [ "https://abdullaev-dotfiles.cachix.org" ];
           extra-trusted-public-keys = [
-            "abdullaev-dotfiles.cachix.org-1:sKeDq8ekKsXv1zUw8xNim0chXcAHdS1i9Z5+5mZB2Ug="
+            "abdullaev-dotfiles.cachix.org-1:ojAEcXkl3aLb8O7Cyt8JOk3yBljFwf/jcUC58Ha3KQ0="
           ];
         };
 


### PR DESCRIPTION
Two commits that missed the PR #2 merge window:

- **closure-aware cachix exclusions** — `cachix push` uploads closures, so the name-only filter leaked excluded packages via aggregates; this subtracts the referrers-closure of excluded paths (verified: reseeded cache contains no font/chrome/obsidian)
- **new cachix signing key** in nix.nix after the cache recreation (the old key is dead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)