### PR TITLE
test: CVE diff path verification (will be closed)

### DIFF
--- a/.github/scripts/cve-report.sh
+++ b/.github/scripts/cve-report.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Render a markdown report (cve-report.md) from vulnxscan CSV output.
+#
+# Usage: cve-report.sh NEW_CSV [BASE_CSV]
+#
+# With BASE_CSV (update PRs): diff report — CVEs introduced/fixed by the
+# update, pre-existing ones as a count only (full lists live in the run
+# artifacts). Both scans must come from the same job so the vulnerability
+# DB snapshot is identical and the diff is attributable to the update.
+#
+# Without BASE_CSV (manual dispatch): absolute report — findings confirmed
+# by >=2 scanners, top 15 by CVSS.
+set -euo pipefail
+
+new_csv=$1
+base_csv=${2-}
+
+# CSV columns: vuln_id,url,package,version_local,severity,grype,osv,vulnix,sum
+# Diff key is CVE id + package: version stays out so a bumped-but-still-
+# vulnerable package counts as pre-existing, not introduced+fixed.
+keys() {
+  awk -F'","' 'NR > 1 {
+    sub(/^"/, "", $1)
+    print $1 "|" $3
+  }' "$1" | sort -u
+}
+
+# Markdown rows for the (cve|package) keys in $2, from csv $1, CVSS desc.
+rows_for_keys() {
+  awk -F'","' -v keyfile="$2" '
+    BEGIN {
+      while ((getline k < keyfile) > 0) K[k] = 1
+    }
+    NR > 1 {
+      id = $1
+      sub(/^"/, "", id)
+      if ((id "|" $3) in K) {
+        sev = ($5 == "" ? 0 : $5 + 0)
+        printf "%06.2f\t| [%s](%s) | %s | %s | %s | %s/%s/%s |\n",
+          sev, id, $2, $3, $4, ($5 == "" ? "-" : $5), $6, $7, $8
+      }
+    }' "$1" | sort -rn | cut -f2- | awk '!seen[$0]++'
+}
+
+section() {
+  local title=$1 rows=$2 n
+  echo "### $title"
+  if [ -s "$rows" ]; then
+    echo "| CVE | package | version | CVSS | grype/osv/vulnix |"
+    echo "|---|---|---|---|---|"
+    head -50 "$rows"
+    n=$(wc -l <"$rows")
+    if [ "$n" -gt 50 ]; then
+      echo
+      echo "…and $((n - 50)) more — see the run artifacts."
+    fi
+  else
+    echo "None."
+  fi
+  echo
+}
+
+if [ -n "$base_csv" ]; then
+  tmp=$(mktemp -d)
+  keys "$new_csv" >"$tmp/new"
+  keys "$base_csv" >"$tmp/base"
+  comm -23 "$tmp/new" "$tmp/base" >"$tmp/introduced"
+  comm -13 "$tmp/new" "$tmp/base" >"$tmp/fixed"
+  pre=$(comm -12 "$tmp/new" "$tmp/base" | wc -l)
+  rows_for_keys "$new_csv" "$tmp/introduced" >"$tmp/introduced.rows"
+  rows_for_keys "$base_csv" "$tmp/fixed" >"$tmp/fixed.rows"
+  {
+    echo "## CVE scan — update diff (advisory)"
+    echo
+    echo "$(wc -l <"$tmp/introduced") introduced, $(wc -l <"$tmp/fixed") fixed," \
+      "$pre pre-existing (unchanged by this update; full lists in the run artifacts)."
+    echo
+    section "Introduced by this update" "$tmp/introduced.rows"
+    section "Fixed by this update" "$tmp/fixed.rows"
+  } >cve-report.md
+  rm -rf "$tmp"
+else
+  {
+    total=$(($(wc -l <"$new_csv") - 1))
+    multi=$(awk -F'","' 'NR > 1 && $9 + 0 >= 2' "$new_csv" | wc -l)
+    echo "## CVE scan (advisory)"
+    echo
+    echo "$total findings; $multi confirmed by >=2 scanners (top 15 by CVSS below)." \
+      "Full report in the run artifacts. Advisory only — name-based matching has false positives."
+    echo
+    echo "| CVE | package | version | CVSS | grype/osv/vulnix |"
+    echo "|---|---|---|---|---|"
+    awk -F'","' 'NR > 1 {
+      sub(/^"/, "", $1)
+      if ($9 + 0 >= 2) {
+        sev = ($5 == "" ? 0 : $5 + 0)
+        printf "%06.2f\t| [%s](%s) | %s | %s | %s | %s/%s/%s |\n",
+          sev, $1, $2, $3, $4, ($5 == "" ? "-" : $5), $6, $7, $8
+      }
+    }' "$new_csv" | sort -rn | cut -f2- | awk 'NR <= 15'
+  } >cve-report.md
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     needs: eval
+    permissions:
+      contents: read
+      pull-requests: write
     # The ~30 GiB closure build: only on the weekly update-flake-lock PRs
     # (their head branch is fixed) and manual dispatch — never on regular PRs.
     if: (github.event_name == 'pull_request' && github.head_ref == 'update_flake_lock_action') || github.event_name == 'workflow_dispatch'
@@ -124,3 +127,41 @@ jobs:
           fi
           comm -23 candidates.txt excluded.txt | tee pushed.txt | cachix push "$CACHIX_CACHE"
           echo "Pushed $(wc -l < pushed.txt) paths ($(wc -l < excluded.txt) excluded as non-redistributable or depending on such)"
+      # Advisory CVE scan of the built closure (vulnxscan = grype + osv.dev
+      # + vulnix). Single-scanner findings are mostly name-match noise, so
+      # the report highlights >=2-scanner hits; full CSV ships as an
+      # artifact. Never fails the job.
+      - name: CVE scan (advisory)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          target=$(nix build --no-update-lock-file --no-link --print-out-paths \
+            .#checks.x86_64-linux.nixos-hosts)
+          nix shell --inputs-from . nixpkgs#sbomnix -c vulnxscan -o vulns.csv "$target" || true
+          {
+            total=$(($(wc -l < vulns.csv) - 1))
+            multi=$(awk -F'","' 'NR>1 && $9+0>=2' vulns.csv | wc -l)
+            echo "## CVE scan (advisory)"
+            echo
+            echo "$total findings; $multi confirmed by >=2 scanners (top 15 by CVSS below)." \
+              "Full report in the run artifacts. Advisory only — name-based matching has false positives."
+            echo
+            echo "| CVE | package | version | CVSS | grype/osv/vulnix |"
+            echo "|---|---|---|---|---|"
+            awk -F'","' 'NR>1 { sub(/^"/,"",$1);
+              if ($9+0>=2) { sev=($5==""?0:$5+0);
+                printf "%06.2f\t| [%s](%s) | %s | %s | %s | %s/%s/%s |\n",
+                  sev,$1,$2,$3,$4,($5==""?"-":$5),$6,$7,$8 } }' vulns.csv \
+              | sort -rn | head -15 | cut -f2-
+          } > cve-report.md
+          cat cve-report.md >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            gh pr comment "${{ github.event.pull_request.number }}" --body-file cve-report.md
+          fi
+      - name: Upload full CVE report
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: cve-report
+          path: vulns.csv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,13 +156,23 @@ jobs:
             connect-timeout = 10
             extra-substituters = https://abdullaev-dotfiles.cachix.org
             extra-trusted-public-keys = abdullaev-dotfiles.cachix.org-1:ojAEcXkl3aLb8O7Cyt8JOk3yBljFwf/jcUC58Ha3KQ0=
+      # On update PRs the base closure is scanned too (same job = same
+      # vulnerability-DB snapshot), so the report can attribute every
+      # difference to the update itself.
+      - name: Checkout PR base
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
       - name: Realize system closure from caches
         run: |
           nix build --no-update-lock-file --no-link -L \
             .#checks.x86_64-linux.nixos-hosts
-      # vulnxscan = grype + osv.dev + vulnix. Single-scanner findings are
-      # mostly name-match noise, so the report highlights >=2-scanner hits;
-      # full CSV ships as an artifact. Advisory: never fails the job.
+      # vulnxscan = grype + osv.dev + vulnix. On update PRs the comment
+      # shows only CVEs introduced/fixed by the update (pre-existing ones
+      # are a count; full CSVs in the artifact). Advisory for findings,
+      # but scanner BREAKAGE fails the job loudly (hence no || true).
       - name: Scan closure for known CVEs
         env:
           GH_TOKEN: ${{ github.token }}
@@ -174,28 +184,14 @@ jobs:
           export XDG_CACHE_HOME=/nix/scanner-cache
           target=$(nix build --no-update-lock-file --no-link --print-out-paths \
             .#checks.x86_64-linux.nixos-hosts)
-          # No || true: scanner FINDINGS exit 0 (advisory), but scanner
-          # BREAKAGE must fail the job loudly.
           nix shell --inputs-from . nixpkgs#sbomnix -c vulnxscan -o vulns.csv "$target"
-          if [ -f vulns.csv ]; then
-            {
-              total=$(($(wc -l < vulns.csv) - 1))
-              multi=$(awk -F'","' 'NR>1 && $9+0>=2' vulns.csv | wc -l)
-              echo "## CVE scan (advisory)"
-              echo
-              echo "$total findings; $multi confirmed by >=2 scanners (top 15 by CVSS below)." \
-                "Full report in the run artifacts. Advisory only — name-based matching has false positives."
-              echo
-              echo "| CVE | package | version | CVSS | grype/osv/vulnix |"
-              echo "|---|---|---|---|---|"
-              awk -F'","' 'NR>1 { sub(/^"/,"",$1);
-                if ($9+0>=2) { sev=($5==""?0:$5+0);
-                  printf "%06.2f\t| [%s](%s) | %s | %s | %s | %s/%s/%s |\n",
-                    sev,$1,$2,$3,$4,($5==""?"-":$5),$6,$7,$8 } }' vulns.csv \
-                | sort -rn | head -15 | cut -f2-
-            } > cve-report.md
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_target=$(nix build --no-update-lock-file --no-link --print-out-paths \
+              ./base#checks.x86_64-linux.nixos-hosts)
+            nix shell --inputs-from . nixpkgs#sbomnix -c vulnxscan -o base-vulns.csv "$base_target"
+            ./.github/scripts/cve-report.sh vulns.csv base-vulns.csv
           else
-            printf '## CVE scan (advisory)\n\nScan produced no results — check the job log.\n' > cve-report.md
+            ./.github/scripts/cve-report.sh vulns.csv
           fi
           cat cve-report.md >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -205,4 +201,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: cve-report
-          path: vulns.csv
+          path: |
+            vulns.csv
+            base-vulns.csv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,9 +167,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Scanner DBs (grype's alone is ~7 GB) fit neither / nor the
+          # residual /mnt; the /nix pool is the only roomy filesystem left,
+          # and non-store dirs there are safe (gc ignores them).
+          sudo mkdir -p /nix/scanner-cache && sudo chown "$(id -un)" /nix/scanner-cache
+          export XDG_CACHE_HOME=/nix/scanner-cache
           target=$(nix build --no-update-lock-file --no-link --print-out-paths \
             .#checks.x86_64-linux.nixos-hosts)
-          nix shell --inputs-from . nixpkgs#sbomnix -c vulnxscan -o vulns.csv "$target" || true
+          # No || true: scanner FINDINGS exit 0 (advisory), but scanner
+          # BREAKAGE must fail the job loudly.
+          nix shell --inputs-from . nixpkgs#sbomnix -c vulnxscan -o vulns.csv "$target"
           if [ -f vulns.csv ]; then
             {
               total=$(($(wc -l < vulns.csv) - 1))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     needs: eval
-    permissions:
-      contents: read
-      pull-requests: write
     # The ~30 GiB closure build: only on the weekly update-flake-lock PRs
     # (their head branch is fixed) and manual dispatch — never on regular PRs.
     if: (github.event_name == 'pull_request' && github.head_ref == 'update_flake_lock_action') || github.event_name == 'workflow_dispatch'
@@ -127,40 +124,76 @@ jobs:
           fi
           comm -23 candidates.txt excluded.txt | tee pushed.txt | cachix push "$CACHIX_CACHE"
           echo "Pushed $(wc -l < pushed.txt) paths ($(wc -l < excluded.txt) excluded as non-redistributable or depending on such)"
-      # Advisory CVE scan of the built closure (vulnxscan = grype + osv.dev
-      # + vulnix). Single-scanner findings are mostly name-match noise, so
-      # the report highlights >=2-scanner hits; full CSV ships as an
-      # artifact. Never fails the job.
-      - name: CVE scan (advisory)
-        continue-on-error: true
+
+  cve-scan:
+    name: CVE scan (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Runs only when full-build succeeded (same gating: update PRs and
+    # manual dispatch). By then all compiles are in Cachix, so realizing
+    # the closure here is downloads-only — no compiling.
+    needs: full-build
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+      # Frees ~115 GB for /nix by purging runner bloat; must precede Nix install.
+      - uses: wimpysworld/nothing-but-nix@v10
+      - name: Load deploy key for private font repo
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.PRAGMATA_PRO_DEPLOY_KEY }}
+      # Pull-only cachix access needs no token — just substituter + key.
+      - uses: DeterminateSystems/nix-installer-action@v22
+        with:
+          extra-conf: |
+            download-attempts = 5
+            connect-timeout = 10
+            extra-substituters = https://abdullaev-dotfiles.cachix.org
+            extra-trusted-public-keys = abdullaev-dotfiles.cachix.org-1:ojAEcXkl3aLb8O7Cyt8JOk3yBljFwf/jcUC58Ha3KQ0=
+      - name: Realize system closure from caches
+        run: |
+          nix build --no-update-lock-file --no-link -L \
+            .#checks.x86_64-linux.nixos-hosts
+      # vulnxscan = grype + osv.dev + vulnix. Single-scanner findings are
+      # mostly name-match noise, so the report highlights >=2-scanner hits;
+      # full CSV ships as an artifact. Advisory: never fails the job.
+      - name: Scan closure for known CVEs
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # grype/vulnix DBs are multi-GB; / has no room after nothing-but-nix
+          # pools its free space into /nix, but TMPDIR lives in that pool.
+          export XDG_CACHE_HOME="$TMPDIR/cache"
           target=$(nix build --no-update-lock-file --no-link --print-out-paths \
             .#checks.x86_64-linux.nixos-hosts)
           nix shell --inputs-from . nixpkgs#sbomnix -c vulnxscan -o vulns.csv "$target" || true
-          {
-            total=$(($(wc -l < vulns.csv) - 1))
-            multi=$(awk -F'","' 'NR>1 && $9+0>=2' vulns.csv | wc -l)
-            echo "## CVE scan (advisory)"
-            echo
-            echo "$total findings; $multi confirmed by >=2 scanners (top 15 by CVSS below)." \
-              "Full report in the run artifacts. Advisory only — name-based matching has false positives."
-            echo
-            echo "| CVE | package | version | CVSS | grype/osv/vulnix |"
-            echo "|---|---|---|---|---|"
-            awk -F'","' 'NR>1 { sub(/^"/,"",$1);
-              if ($9+0>=2) { sev=($5==""?0:$5+0);
-                printf "%06.2f\t| [%s](%s) | %s | %s | %s | %s/%s/%s |\n",
-                  sev,$1,$2,$3,$4,($5==""?"-":$5),$6,$7,$8 } }' vulns.csv \
-              | sort -rn | head -15 | cut -f2-
-          } > cve-report.md
+          if [ -f vulns.csv ]; then
+            {
+              total=$(($(wc -l < vulns.csv) - 1))
+              multi=$(awk -F'","' 'NR>1 && $9+0>=2' vulns.csv | wc -l)
+              echo "## CVE scan (advisory)"
+              echo
+              echo "$total findings; $multi confirmed by >=2 scanners (top 15 by CVSS below)." \
+                "Full report in the run artifacts. Advisory only — name-based matching has false positives."
+              echo
+              echo "| CVE | package | version | CVSS | grype/osv/vulnix |"
+              echo "|---|---|---|---|---|"
+              awk -F'","' 'NR>1 { sub(/^"/,"",$1);
+                if ($9+0>=2) { sev=($5==""?0:$5+0);
+                  printf "%06.2f\t| [%s](%s) | %s | %s | %s | %s/%s/%s |\n",
+                    sev,$1,$2,$3,$4,($5==""?"-":$5),$6,$7,$8 } }' vulns.csv \
+                | sort -rn | head -15 | cut -f2-
+            } > cve-report.md
+          else
+            printf '## CVE scan (advisory)\n\nScan produced no results — check the job log.\n' > cve-report.md
+          fi
           cat cve-report.md >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             gh pr comment "${{ github.event.pull_request.number }}" --body-file cve-report.md
           fi
       - name: Upload full CVE report
-        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: cve-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,12 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
-      # Frees ~115 GB for /nix by purging runner bloat; must precede Nix install.
+      # holster (not cleave): takes only /mnt (~65 GB, enough for the closure)
+      # and leaves / untouched — grype's DB hydration needs several GB of
+      # scratch on / that cleave would have drained into the /nix pool.
       - uses: wimpysworld/nothing-but-nix@v10
+        with:
+          hatchet-protocol: holster
       - name: Load deploy key for private font repo
         uses: webfactory/ssh-agent@v0.10.0
         with:
@@ -163,9 +167,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # grype/vulnix DBs are multi-GB; / has no room after nothing-but-nix
-          # pools its free space into /nix, but TMPDIR lives in that pool.
-          export XDG_CACHE_HOME="$TMPDIR/cache"
           target=$(nix build --no-update-lock-file --no-link --print-out-paths \
             .#checks.x86_64-linux.nixos-hosts)
           nix shell --inputs-from . nixpkgs#sbomnix -c vulnxscan -o vulns.csv "$target" || true


### PR DESCRIPTION
Throwaway PR to exercise the update-PR CVE diff path end-to-end (branch name triggers the full-build + cve-scan gate). Will be closed without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)